### PR TITLE
chore: migrate pre-existing data science projects

### DIFF
--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -185,12 +185,8 @@ func (ossm *Ossm) migrateDSProjects() error {
 		annotations["opendatahub.io/service-mesh"] = "true"
 		ns.SetAnnotations(annotations)
 
-		// Update the namespace with the new annotation
-		_, err = client.CoreV1().Namespaces().Update(context.TODO(), &ns, metav1.UpdateOptions{})
-		if err != nil {
-			// Add the error to multierror
-			result = multierror.Append(result, fmt.Errorf("failed to update namespace %s: %v", ns.GetName(), err))
-			continue
+		if _, err := client.CoreV1().Namespaces().Update(context.TODO(), &ns, metav1.UpdateOptions{}); err != nil {
+			result = multierror.Append(result, err)
 		}
 	}
 

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -190,7 +190,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 		}
 	}
 
-	// Return the error(s) if any
 	return result.ErrorOrNil()
 }
 

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -174,7 +174,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 		return fmt.Errorf("failed to get namespaces: %v", err)
 	}
 
-	// Initialize multierror
 	var result *multierror.Error
 
 	for _, ns := range namespaces.Items {

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -165,7 +165,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 		return err
 	}
 
-	// Define the selector to find the namespaces we are interested in
 	selector := labels.SelectorFromSet(labels.Set{"opendatahub.io/dashboard": "true"})
 
 	// List the namespaces with the specific label

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -87,10 +87,8 @@ func (ossm *Ossm) Init(resources kftypesv3.ResourceEnum) error {
 		return internalError(err)
 	}
 
-	var dsErr error
-	if dsErr = ossm.migrateDSProjects(); dsErr != nil {
-		// Just log the error here but don't return
-		log.Error(dsErr, "Error while migrating DS Projects")
+	if err := ossm.migrateDSProjects(); err != nil {
+		log.Error(err, "failed migrating Data Science Projects")
 	}
 
 	if err := ossm.processManifests(); err != nil {

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -167,7 +167,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 
 	selector := labels.SelectorFromSet(labels.Set{"opendatahub.io/dashboard": "true"})
 
-	// List the namespaces with the specific label
 	namespaces, err := client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return fmt.Errorf("failed to get namespaces: %v", err)

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -177,7 +177,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 	// Initialize multierror
 	var result *multierror.Error
 
-	// Iterate over the namespaces and add or update the annotation
 	for _, ns := range namespaces.Items {
 		// Define the annotation to be added
 		annotations := ns.GetAnnotations()

--- a/pkg/kfapp/ossm/ossm_installer.go
+++ b/pkg/kfapp/ossm/ossm_installer.go
@@ -178,7 +178,6 @@ func (ossm *Ossm) migrateDSProjects() error {
 	var result *multierror.Error
 
 	for _, ns := range namespaces.Items {
-		// Define the annotation to be added
 		annotations := ns.GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-4376

Adds a step to Init() migrating pre-existing data science projects to be part of the mesh. Does so by selecting namespaces with the dashboard:true label, and then setting the service-mesh annotation to true for these namespaces.

Operator `quay.io/maistra-dev/opendatahub-operator:v0.0.5-dsp` tested on CRC by manually creating a namespace with label `opendatahub.io/dashboard: "true"`, creating a KfDef with the plugin enabled, and then checking that the annotation had been added, and was found by the project-controller.