### PR TITLE
fix: extracts port from URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: test-ossm
 test-ossm: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./pkg/kfapp/ossm/... -coverprofile cover.out
+	go test ./pkg/kfapp/ossm/... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./tests/integration/... -coverprofile cover.out
 
 ##@ Build
 

--- a/apis/kfconfig.apps.kubeflow.org/v1alpha1/kfconfig_types.go
+++ b/apis/kfconfig.apps.kubeflow.org/v1alpha1/kfconfig_types.go
@@ -408,13 +408,16 @@ func (c *KfConfig) SetPluginFailed(pluginKind PluginKindType, msg string) {
 // I don't think the code is currently setting the local directory for the cache correctly in
 // that case.
 //
-//
 // Using tarball vs. archive in github links affects the download path
 // e.g.
 // https://github.com/kubeflow/manifests/tarball/master?archive=tar.gz
-//    unpacks to  kubeflow-manifests-${COMMIT}
+//
+//	unpacks to  kubeflow-manifests-${COMMIT}
+//
 // https://github.com/kubeflow/manifests/archive/master.tar.gz
-//    unpacks to manifests-master
+//
+//	unpacks to manifests-master
+//
 // Always use archive format so that the path is predetermined.
 //
 // Instructions: https://github.com/hashicorp/go-getter#protocol-specific-options
@@ -422,13 +425,12 @@ func (c *KfConfig) SetPluginFailed(pluginKind PluginKindType, msg string) {
 // What is the correct syntax for downloading pull requests?
 // The following doesn't seem to work
 // https://github.com/kubeflow/manifests/archive/master.tar.gz?ref=pull/188
-//   * Appears to download master
+//   - Appears to download master
 //
 // This appears to work
 // https://github.com/kubeflow/manifests/tarball/pull/188/head?archive=tar.gz
 // But unpacks it into
 // kubeflow-manifests-${COMMIT}
-//
 func (c *KfConfig) SyncCache() error {
 	if c.Spec.AppDir == "" {
 		return fmt.Errorf("AppDir must be specified")

--- a/pkg/kfapp/ossm/cleanup.go
+++ b/pkg/kfapp/ossm/cleanup.go
@@ -28,7 +28,7 @@ func (o *OssmInstaller) onCleanup(cleanupFunc ...cleanup) {
 	o.cleanupFuncs = append(o.cleanupFuncs, cleanupFunc...)
 }
 
-// createResourceTracker instantiates OssmResourceTracker for given KfDef application in a namespce.
+// createResourceTracker instantiates OssmResourceTracker for given KfDef application in a namespace.
 // This cluster-scoped resource is used as OwnerReference in all objects OssmInstaller is created across the cluster.
 // Once created, there's a cleanup function added which will be invoked on deletion of the KfDef.
 func (o *OssmInstaller) createResourceTracker() error {

--- a/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
+++ b/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 var _ = Describe("extracting hostname and port from URL", func() {
+
 	It("should extract hostname and port for HTTP URL", func() {
 		hostname, port, err := ossm.ExtractHostNameAndPort("http://opendatahub.io:8080/path")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hostname).To(Equal("opendatahub.io"))
 		Expect(port).To(Equal("8080"))
 	})
-
 
 	It("should return original URL if it does not start with http(s) but with other valid protocol", func() {
 		originalURL := "gopher://opendatahub.io"

--- a/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
+++ b/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
@@ -1,0 +1,52 @@
+package ossm_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/opendatahub-operator/pkg/kfapp/ossm"
+)
+
+var _ = Describe("extracting hostname and port from URL", func() {
+	It("should extract hostname and port for HTTP URL", func() {
+		hostname, port, err := ossm.ExtractHostNameAndPort("http://opendatahub.io:8080/path")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostname).To(Equal("opendatahub.io"))
+		Expect(port).To(Equal("8080"))
+	})
+
+	It("should extract hostname and default port 443 for HTTPS URL", func() {
+		hostname, port, err := ossm.ExtractHostNameAndPort("https://opendatahub.io")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostname).To(Equal("opendatahub.io"))
+		Expect(port).To(Equal("443"))
+	})
+
+	It("should return original URL if it does not start with http(s) but with other valid protocol", func() {
+		originalURL := "gopher://opendatahub.io"
+		hostname, port, err := ossm.ExtractHostNameAndPort(originalURL)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostname).To(Equal(originalURL))
+		Expect(port).To(Equal(""))
+	})
+
+	It("should handle invalid URLs by returning corresponding error", func() {
+		invalidURL := ":opendatahub.io"
+		_, _, err := ossm.ExtractHostNameAndPort(invalidURL)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("missing protocol scheme")))
+	})
+
+	It("should handle URLs without port and default to 443 for HTTPS", func() {
+		hostname, port, err := ossm.ExtractHostNameAndPort("https://opendatahub.io")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostname).To(Equal("opendatahub.io"))
+		Expect(port).To(Equal("443"))
+	})
+
+	It("should handle URLs without port and default to 80 for HTTP", func() {
+		hostname, port, err := ossm.ExtractHostNameAndPort("http://opendatahub.io")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hostname).To(Equal("opendatahub.io"))
+		Expect(port).To(Equal("80"))
+	})
+})

--- a/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
+++ b/pkg/kfapp/ossm/hostname_and_port_extraction_unit_test.go
@@ -14,12 +14,6 @@ var _ = Describe("extracting hostname and port from URL", func() {
 		Expect(port).To(Equal("8080"))
 	})
 
-	It("should extract hostname and default port 443 for HTTPS URL", func() {
-		hostname, port, err := ossm.ExtractHostNameAndPort("https://opendatahub.io")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(hostname).To(Equal("opendatahub.io"))
-		Expect(port).To(Equal("443"))
-	})
 
 	It("should return original URL if it does not start with http(s) but with other valid protocol", func() {
 		originalURL := "gopher://opendatahub.io"

--- a/pkg/kfapp/ossm/ossm_manifests.go
+++ b/pkg/kfapp/ossm/ossm_manifests.go
@@ -165,10 +165,16 @@ func (o *OssmInstaller) prepareTemplateData() (interface{}, error) {
 	}
 
 	if oauthServerDetailsJson, err := GetOAuthServerDetails(); err == nil {
+		hostName, port, errUrlParsing := ExtractHostNameAndPort(oauthServerDetailsJson.Get("issuer").MustString("issuer"))
+		if errUrlParsing != nil {
+			return nil, internalError(errUrlParsing)
+		}
+
 		data.OAuth = oAuth{
 			AuthzEndpoint: oauthServerDetailsJson.Get("authorization_endpoint").MustString("authorization_endpoint"),
 			TokenEndpoint: oauthServerDetailsJson.Get("token_endpoint").MustString("token_endpoint"),
-			Route:         ExtractHostName(oauthServerDetailsJson.Get("issuer").MustString("issuer")),
+			Route:         hostName,
+			Port:          port,
 			ClientSecret:  clientSecret.Value,
 			Hmac:          hmac.Value,
 		}

--- a/pkg/kfapp/ossm/ossm_suite_test.go
+++ b/pkg/kfapp/ossm/ossm_suite_test.go
@@ -1,98 +1,14 @@
 package ossm_test
 
 import (
-	"context"
-	"fmt"
-	v1 "k8s.io/api/core/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"os"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var (
-	cli     client.Client
-	envTest *envtest.Environment
-	ctx     context.Context
-	cancel  context.CancelFunc
-)
-
-var testScheme = runtime.NewScheme()
-
-func TestOssmPlugin(t *testing.T) {
+func TestOssmInstaller(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Openshift Service Mesh infra setup integration")
-}
-
-var _ = BeforeSuite(func() {
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	opts := zap.Options{Development: true}
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
-
-	By("Bootstrapping k8s test environment")
-	projectDir, err := findProjectRoot()
-	if err != nil {
-		fmt.Printf("Error finding project root: %v\n", err)
-		return
-	}
-
-	utilruntime.Must(v1.AddToScheme(testScheme))
-
-	envTest = &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Scheme: testScheme,
-			Paths: []string{
-				filepath.Join(projectDir, "config", "crd", "bases"),
-				filepath.Join(projectDir, "config", "crd", "dashboard-crds"),
-			},
-			ErrorIfPathMissing: true,
-			CleanUpAfterUse:    false,
-		},
-	}
-
-	cfg, err := envTest.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	cli, err = client.New(cfg, client.Options{Scheme: testScheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cli).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	By("Tearing down the test environment")
-	cancel()
-	Expect(envTest.Stop()).To(Succeed())
-})
-
-func findProjectRoot() (string, error) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
-			return filepath.FromSlash(currentDir), nil
-		}
-
-		parentDir := filepath.Dir(currentDir)
-		if parentDir == currentDir {
-			break
-		}
-
-		currentDir = parentDir
-	}
-
-	return "", fmt.Errorf("project root not found")
+	// for integration tests see tests/integration directory
+	RunSpecs(t, "Openshift Service Mesh installer unit tests")
 }

--- a/pkg/kfapp/ossm/types.go
+++ b/pkg/kfapp/ossm/types.go
@@ -16,6 +16,7 @@ type oAuth struct {
 	AuthzEndpoint,
 	TokenEndpoint,
 	Route,
+	Port,
 	ClientSecret,
 	Hmac string
 }

--- a/pkg/kfconfig/loaders/loaders.go
+++ b/pkg/kfconfig/loaders/loaders.go
@@ -39,8 +39,9 @@ func isValidUrl(toTest string) bool {
 // LoadConfigFromURI reads the kfdef from a remote URI or local file,
 // and returns the kfconfig.
 // It will set the AppDir and ConfigFilename in kfconfig:
-//   AppDir = cwd if configFile is remote, or it will be the dir of configFile.
-//   ConfigFilename = the file name of configFile.
+//
+//	AppDir = cwd if configFile is remote, or it will be the dir of configFile.
+//	ConfigFilename = the file name of configFile.
 func LoadConfigFromURI(configFile string) (*kfconfig.KfConfig, error) {
 	if configFile == "" {
 		return nil, fmt.Errorf("config file must be the URI of a KfDef spec")

--- a/tests/integration/ossm_installer_int_test.go
+++ b/tests/integration/ossm_installer_int_test.go
@@ -32,8 +32,8 @@ var _ = When("Migrating Data Science Projects", func() {
 
 	It("should find one namespace to migrate", func() {
 		// given
-		dataScienceNs := createDSProject("dsp-01")
-		regularNs := createNs("non-dsp")
+		dataScienceNs := createDataScienceProject("dsp-01")
+		regularNs := createNamespace("non-dsp")
 		Expect(cli.Create(context.Background(), dataScienceNs)).To(Succeed())
 		Expect(cli.Create(context.Background(), regularNs)).To(Succeed())
 		defer objectCleaner.DeleteAll(dataScienceNs, regularNs)
@@ -59,15 +59,15 @@ var _ = When("Migrating Data Science Projects", func() {
 
 })
 
-func createDSProject(name string) *v1.Namespace {
-	namespace := createNs(name)
+func createDataScienceProject(name string) *v1.Namespace {
+	namespace := createNamespace(name)
 	namespace.Labels = map[string]string{
 		"opendatahub.io/dashboard": "true",
 	}
 	return namespace
 }
 
-func createNs(name string) *v1.Namespace {
+func createNamespace(name string) *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/tests/integration/ossm_installer_int_test.go
+++ b/tests/integration/ossm_installer_int_test.go
@@ -45,7 +45,8 @@ var _ = When("Migrating Data Science Projects", func() {
 		Eventually(findMigratedNamespaces, timeout, interval).Should(
 			And(
 				HaveLen(1),
-				ContainElement("dsp-01")),
+				ContainElement("dsp-01")
+		),
 		)
 	})
 
@@ -81,7 +82,8 @@ var _ = When("Migrating Data Science Projects", func() {
 		Eventually(findMigratedNamespaces, timeout, interval).Should(
 			And(
 				HaveLen(3),
-				ContainElements("dsp-01", "dsp-02", "dsp-03")),
+				ContainElements("dsp-01", "dsp-02", "dsp-03")
+		),
 		)
 	})
 

--- a/tests/integration/ossm_suite_int_test.go
+++ b/tests/integration/ossm_suite_int_test.go
@@ -1,0 +1,103 @@
+package ossm_test
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"os"
+	"path/filepath"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	cli     client.Client
+	envTest *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+)
+
+var testScheme = runtime.NewScheme()
+
+func TestOssmInstallerIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Openshift Service Mesh infra setup integration")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	opts := zap.Options{Development: true}
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
+
+	By("Bootstrapping k8s test environment")
+	projectDir, err := findProjectRoot()
+	if err != nil {
+		fmt.Printf("Error finding project root: %v\n", err)
+		return
+	}
+
+	utilruntime.Must(v1.AddToScheme(testScheme))
+
+	envTest = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Scheme: testScheme,
+			Paths: []string{
+				filepath.Join(projectDir, "config", "crd", "bases"),
+				filepath.Join(projectDir, "config", "crd", "dashboard-crds"),
+			},
+			ErrorIfPathMissing: true,
+			CleanUpAfterUse:    false,
+		},
+	}
+
+	cfg, err := envTest.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	cli, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cli).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	if strings.Contains(CurrentGinkgoTestDescription().FileName, "unit_test") {
+		fmt.Println("skipping for unit tests")
+		return
+	}
+	By("Tearing down the test environment")
+	cancel()
+	Expect(envTest.Stop()).To(Succeed())
+})
+
+func findProjectRoot() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
+			return filepath.FromSlash(currentDir), nil
+		}
+
+		parentDir := filepath.Dir(currentDir)
+		if parentDir == currentDir {
+			break
+		}
+
+		currentDir = parentDir
+	}
+
+	return "", fmt.Errorf("project root not found")
+}


### PR DESCRIPTION
In addition, moved integration tests to their own folder so we can add unit tests to the ossm installer without the need of starting kube testenv.  Main reason behind it is that we cannot use labels in Ginkgo as we do in [project controller](https://github.com/maistra/odh-project-controller/commit/e5c5536f86b269250596e292ba9302a79ec2d838) because we are stuck with v1 of test framework. Updating to v2 causes a lot of dependency issues